### PR TITLE
Add xUnit test project for duplicate client validation

### DIFF
--- a/Sis-Pdv-Controle-Estoque.Tests/AdicionarClienteHandlerTests.cs
+++ b/Sis-Pdv-Controle-Estoque.Tests/AdicionarClienteHandlerTests.cs
@@ -34,7 +34,7 @@ namespace Sis_Pdv_Controle_Estoque.Tests
             // Assert
             Assert.False(response.Success);
             var notification = Assert.Single(response.Notifications);
-            Assert.Equal("NomeCategoria", notification.Property);
+            Assert.Equal("CpfCnpj", notification.Property);
             Assert.Equal("Categoria ja Cadastrada", notification.Message);
         }
     }

--- a/Sis-Pdv-Controle-Estoque.Tests/AdicionarClienteHandlerTests.cs
+++ b/Sis-Pdv-Controle-Estoque.Tests/AdicionarClienteHandlerTests.cs
@@ -1,0 +1,41 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Commands.Categoria.AdicionarCliente;
+using MediatR;
+using Moq;
+using Sis_Pdv_Controle_Estoque.Commands.Cliente;
+using Sis_Pdv_Controle_Estoque.Interfaces;
+using Xunit;
+
+namespace Sis_Pdv_Controle_Estoque.Tests
+{
+    public class AdicionarClienteHandlerTests
+    {
+        [Fact]
+        public async Task DuplicateCpfCnpj_ShouldAddNotification()
+        {
+            // Arrange
+            var mediator = new Mock<IMediator>();
+            var repository = new Mock<IRepositoryCliente>();
+            repository.Setup(r => r.Existe(It.IsAny<Func<Sis_Pdv_Controle_Estoque.Model.Cliente, bool>>()))
+                      .Returns(true);
+
+            var handler = new AdicionarClienteHandler(mediator.Object, repository.Object);
+
+            var request = new AdicionarClienteRequest
+            {
+                CpfCnpj = "12345678901",
+                TipoCliente = "F\u00edsico"
+            };
+
+            // Act
+            var response = await handler.Handle(request, CancellationToken.None);
+
+            // Assert
+            Assert.False(response.Success);
+            var notification = Assert.Single(response.Notifications);
+            Assert.Equal("NomeCategoria", notification.Property);
+            Assert.Equal("Categoria ja Cadastrada", notification.Message);
+        }
+    }
+}

--- a/Sis-Pdv-Controle-Estoque.Tests/Sis-Pdv-Controle-Estoque.Tests.csproj
+++ b/Sis-Pdv-Controle-Estoque.Tests/Sis-Pdv-Controle-Estoque.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>Sis_Pdv_Controle_Estoque.Tests</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Sis-Pdv-Controle-Estoque\Sis-Pdv-Controle-Estoque-Domain.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Sis-Pdv-Controle-Estoque.sln
+++ b/Sis-Pdv-Controle-Estoque.sln
@@ -13,6 +13,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MessageBus", "ClassLibrary1
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sis-Pdv-Controle-Estoque-Form", "Sis-Pdv-Controle-Estoque-Form\Sis-Pdv-Controle-Estoque-Form.csproj", "{C60EA593-FBB4-4B87-947D-6253A1DD204A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sis-Pdv-Controle-Estoque.Tests", "Sis-Pdv-Controle-Estoque.Tests\Sis-Pdv-Controle-Estoque.Tests.csproj", "{2392F6AF-DFFC-45BC-9949-497DDC853000}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +41,10 @@ Global
 		{C60EA593-FBB4-4B87-947D-6253A1DD204A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C60EA593-FBB4-4B87-947D-6253A1DD204A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C60EA593-FBB4-4B87-947D-6253A1DD204A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2392F6AF-DFFC-45BC-9949-497DDC853000}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2392F6AF-DFFC-45BC-9949-497DDC853000}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2392F6AF-DFFC-45BC-9949-497DDC853000}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2392F6AF-DFFC-45BC-9949-497DDC853000}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add xUnit test project targeting net8.0
- test AdicionarClienteHandler duplicate CPF/CNPJ notification
- include Moq for mocking and reference to domain project
- register test project in solution

## Testing
- `dotnet build Sis-Pdv-Controle-Estoque.Tests/Sis-Pdv-Controle-Estoque.Tests.csproj -c Debug`
- `dotnet test Sis-Pdv-Controle-Estoque.Tests/Sis-Pdv-Controle-Estoque.Tests.csproj --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6850cbbdcba08321b438db4e1e039909