### PR TITLE
Fix ProdutoPedido update logic

### DIFF
--- a/Sis-Pdv-Controle-Estoque/Commands/ProdutoPedido/AlterarProdutoPedido/AlterarProdutoPedidoHandler.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/ProdutoPedido/AlterarProdutoPedido/AlterarProdutoPedidoHandler.cs
@@ -36,9 +36,14 @@ namespace Commands.ProdutoPedido.AlterarProdutoPedido
                 return new Response(this);
             }
 
-            Sis_Pdv_Controle_Estoque.Model.ProdutoPedido ProdutoPedido = new Sis_Pdv_Controle_Estoque.Model.ProdutoPedido();
+            var produtoPedido = _repositoryProdutoPedido.ObterPorId(request.Id);
+            if (produtoPedido == null)
+            {
+                AddNotification("ProdutoPedido", "Registro não encontrado");
+                return new Response(this);
+            }
 
-            ProdutoPedido.AlterarProdutoPedido(
+            produtoPedido.AlterarProdutoPedido(
                                                 request.PedidoId,
                                                 request.ProdutoId,
                                                 request.codBarras,
@@ -46,17 +51,10 @@ namespace Commands.ProdutoPedido.AlterarProdutoPedido
                                                 request.totalProdutoPedido
                 );
 
-            var retornoExist = _repositoryProdutoPedido.Listar().Where(x => x.Id == request.Id);
-            if (!retornoExist.Any())
-            {
-                AddNotification("ProdutoPedido", "");
-                return new Response(this);
-            }
-
-            ProdutoPedido = _repositoryProdutoPedido.Editar(ProdutoPedido);
+            produtoPedido = _repositoryProdutoPedido.Editar(produtoPedido);
 
             //Criar meu objeto de resposta
-            var response = new Sis_Pdv_Controle_Estoque.Commands.Response(this, ProdutoPedido);
+            var response = new Sis_Pdv_Controle_Estoque.Commands.Response(this, produtoPedido);
 
             return await Task.FromResult(response);
         }

--- a/Sis-Pdv-Controle-Estoque/Model/ProdutoPedido.cs
+++ b/Sis-Pdv-Controle-Estoque/Model/ProdutoPedido.cs
@@ -41,8 +41,10 @@ namespace Sis_Pdv_Controle_Estoque.Model
 
         internal void AlterarProdutoPedido(Guid pedidoId, Guid produtoId, string codBarras, int quantidadeItemPedido, decimal totalProdutoPedido)
         {
-            new Pedido { Id = pedidoId };
-            new Produto { Id = produtoId };
+            PedidoId = pedidoId;
+            ProdutoId = produtoId;
+            Pedido = new Pedido { Id = pedidoId };
+            Produto = new Produto { Id = produtoId };
             this.codBarras = codBarras;
             this.quantidadeItemPedido = quantidadeItemPedido;
             this.totalProdutoPedido = totalProdutoPedido;


### PR DESCRIPTION
## Summary
- ensure AlterarProdutoPedido assigns IDs and navigation properties
- update handler to fetch existing ProdutoPedido and apply changes

## Testing
- `dotnet restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850ca4d58808321a90aff61a2465fdf