### PR TITLE
Fix notification property for duplicate client

### DIFF
--- a/Sis-Pdv-Controle-Estoque/Commands/Cliente/AdicionarCliente/AdicionarClienteHandler.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Cliente/AdicionarCliente/AdicionarClienteHandler.cs
@@ -47,7 +47,7 @@ namespace Sis_Pdv_Controle_Estoque.Commands.Cliente
             //Verificar se o usuário já existe
             if (_repositoryCliente.Existe(x => x.CpfCnpj == request.CpfCnpj))
             {
-                AddNotification("NomeCategoria", "Categoria ja Cadastrada");
+                AddNotification("CpfCnpj", "Categoria ja Cadastrada");
                 return new Response(this);
             }
 


### PR DESCRIPTION
## Summary
- fix AddNotification property in `AdicionarClienteHandler`
- run unit tests

## Testing
- `dotnet test Sis-Pdv-Controle-Estoque.Tests/Sis-Pdv-Controle-Estoque.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6850cf816b3c8321a62ed4a234d12a0d