### PR TITLE
Fix domain namespaces with global usings

### DIFF
--- a/Sis-Pdv-Controle-Estoque-Infra/GlobalUsings.cs
+++ b/Sis-Pdv-Controle-Estoque-Infra/GlobalUsings.cs
@@ -1,0 +1,4 @@
+global using Model;
+global using Interfaces;
+global using Interfaces.Repositories.Base;
+

--- a/Sis-Pdv-Controle-Estoque/Commands/Colaborador/ListarColaborador/ListarColaboradorHandler.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Colaborador/ListarColaborador/ListarColaboradorHandler.cs
@@ -5,7 +5,7 @@ using prmToolkit.NotificationPattern;
 
 namespace Commands.Colaborador.ListarColaborador
 {
-    public class ListarColaboradorPorIdHandler : Notifiable, IRequestHandler<ListarColaboradorRequest, Sis_Pdv_Controle_Estoque.Commands.Response>
+    public class ListarColaboradorPorIdHandler : Notifiable, IRequestHandler<ListarColaboradorRequest, Commands.Response>
     {
         private readonly IMediator _mediator;
         private readonly IRepositoryColaborador _repositoryColaborador;
@@ -18,13 +18,13 @@ namespace Commands.Colaborador.ListarColaborador
             _repositoryDepartamento = repositoryDepartamento;
         }
 
-        public async Task<Sis_Pdv_Controle_Estoque.Commands.Response> Handle(ListarColaboradorRequest request, CancellationToken cancellationToken)
+        public async Task<Commands.Response> Handle(ListarColaboradorRequest request, CancellationToken cancellationToken)
         {
             //Valida se o objeto request esta nulo
             if (request == null)
             {
                 AddNotification("Request", "");
-                return new Sis_Pdv_Controle_Estoque.Commands.Response(this);
+                return new Commands.Response(this);
             }
 
 
@@ -32,7 +32,7 @@ namespace Commands.Colaborador.ListarColaborador
 
 
             //Cria objeto de resposta
-            var response = new Sis_Pdv_Controle_Estoque.Commands.Response(this, grupoCollection);
+            var response = new Commands.Response(this, grupoCollection);
 
             ////Retorna o resultado
             return await Task.FromResult(response);

--- a/Sis-Pdv-Controle-Estoque/Commands/Colaborador/ListarColaborador/ListarColaboradorRequest.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Colaborador/ListarColaborador/ListarColaboradorRequest.cs
@@ -2,7 +2,7 @@
 
 namespace Commands.Colaborador.ListarColaborador
 {
-    public class ListarColaboradorRequest : IRequest<Sis_Pdv_Controle_Estoque.Commands.Response>
+    public class ListarColaboradorRequest : IRequest<Commands.Response>
     {
     }
 }

--- a/Sis-Pdv-Controle-Estoque/Commands/Colaborador/RemoverColaborador/RemoverColaboradorHandler.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Colaborador/RemoverColaborador/RemoverColaboradorHandler.cs
@@ -5,7 +5,7 @@ using prmToolkit.NotificationPattern;
 namespace Commands.Colaborador.RemoverColaborador
 
 {
-    public class RemoverColaboradorHandler : Notifiable, IRequestHandler<RemoverColaboradorResquest, Sis_Pdv_Controle_Estoque.Commands.Response>
+    public class RemoverColaboradorHandler : Notifiable, IRequestHandler<RemoverColaboradorResquest, Commands.Response>
     {
         private readonly IMediator _mediator;
         private readonly IRepositoryColaborador _repositoryColaborador;
@@ -17,33 +17,33 @@ namespace Commands.Colaborador.RemoverColaborador
             _repositoryUsuario = repositoryUsuario;
         }
 
-        public async Task<Sis_Pdv_Controle_Estoque.Commands.Response> Handle(RemoverColaboradorResquest request, CancellationToken cancellationToken)
+        public async Task<Commands.Response> Handle(RemoverColaboradorResquest request, CancellationToken cancellationToken)
         {
             //Valida se o objeto request esta nulo
             if (request == null)
             {
                 AddNotification("Request", "");
-                return new Sis_Pdv_Controle_Estoque.Commands.Response(this);
+                return new Commands.Response(this);
             }
 
-            Sis_Pdv_Controle_Estoque.Model.Colaborador Colaborador = _repositoryColaborador.Listar().
+            Model.Colaborador Colaborador = _repositoryColaborador.Listar().
                 Include(x => x.Usuario).
                 Where(x => x.Id == request.Id).FirstOrDefault();
 
             if (Colaborador == null)
             {
                 AddNotification("Request", "");
-                return new Sis_Pdv_Controle_Estoque.Commands.Response(this);
+                return new Commands.Response(this);
             }
             if (Colaborador.Id == null)
             {
                 AddNotification("Request", "Colaborador.Id");
-                return new Sis_Pdv_Controle_Estoque.Commands.Response(this);
+                return new Commands.Response(this);
             }
             //if (Colaborador.Usuario.Id == null)
             //{
             //    AddNotification("Request", "Colaborador.Usuario.Id");
-            //    return new Sis_Pdv_Controle_Estoque.Commands.Response(this);
+            //    return new Commands.Response(this);
             //}
             _repositoryUsuario.Remover(Colaborador.Usuario);
             _repositoryColaborador.Remover(Colaborador);
@@ -51,7 +51,7 @@ namespace Commands.Colaborador.RemoverColaborador
             var result = new { Colaborador.Id };
 
             //Cria objeto de resposta
-            var response = new Sis_Pdv_Controle_Estoque.Commands.Response(this, Colaborador);
+            var response = new Commands.Response(this, Colaborador);
 
             ////Retorna o resultado
             return await Task.FromResult(response);

--- a/Sis-Pdv-Controle-Estoque/Commands/Colaborador/ValidarColaboradorLogin/ValidarColaboradorLoginHandler.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Colaborador/ValidarColaboradorLogin/ValidarColaboradorLoginHandler.cs
@@ -4,7 +4,7 @@ using prmToolkit.NotificationPattern;
 
 namespace Commands.Colaborador.ValidarColaboradorLogin
 {
-    public class ValidarColaboradorLoginHandler : Notifiable, IRequestHandler<ValidarColaboradorLoginRequest, Sis_Pdv_Controle_Estoque.Commands.Response>
+    public class ValidarColaboradorLoginHandler : Notifiable, IRequestHandler<ValidarColaboradorLoginRequest, Commands.Response>
     {
         private readonly IMediator _mediator;
         private readonly IRepositoryColaborador _repositoryColaborador;
@@ -51,7 +51,7 @@ namespace Commands.Colaborador.ValidarColaboradorLogin
             }
 
             //Cria objeto de resposta
-            var response = new Sis_Pdv_Controle_Estoque.Commands.Response(this, result);
+            var response = new Commands.Response(this, result);
 
             ////Retorna o resultado
             return await Task.FromResult(response);

--- a/Sis-Pdv-Controle-Estoque/Commands/Departamento/AlterarDepartamento/AlterarDepartamentoHandler.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Departamento/AlterarDepartamento/AlterarDepartamentoHandler.cs
@@ -3,7 +3,7 @@ using prmToolkit.NotificationPattern;
 
 namespace Commands.Departamento.AlterarDepartamento
 {
-    public class AlterarDepartamentoHandler : Notifiable, IRequestHandler<AlterarDepartamentoRequest, Sis_Pdv_Controle_Estoque.Commands.Response>
+    public class AlterarDepartamentoHandler : Notifiable, IRequestHandler<AlterarDepartamentoRequest, Commands.Response>
     {
         private readonly IMediator _mediator;
         private readonly IRepositoryDepartamento _repositoryDepartamento;
@@ -14,23 +14,23 @@ namespace Commands.Departamento.AlterarDepartamento
             _repositoryDepartamento = repositoryDepartamento;
         }
 
-        public async Task<Sis_Pdv_Controle_Estoque.Commands.Response> Handle(AlterarDepartamentoRequest request, CancellationToken cancellationToken)
+        public async Task<Commands.Response> Handle(AlterarDepartamentoRequest request, CancellationToken cancellationToken)
         {
             //Validar se o requeste veio preenchido
             if (request == null)
             {
                 AddNotification("Departamento", "");
-                return new Sis_Pdv_Controle_Estoque.Commands.Response(this);
+                return new Commands.Response(this);
             }
 
-            Sis_Pdv_Controle_Estoque.Model.Departamento departamento = new Sis_Pdv_Controle_Estoque.Model.Departamento();
+            Model.Departamento departamento = new Model.Departamento();
 
             departamento.AlterarDepartamento(request.Id, request.NomeDepartamento);
             var retornoExist = _repositoryDepartamento.Listar().Where(x => x.Id == request.Id);
             if (!retornoExist.Any())
             {
                 AddNotification("Departamento", "");
-                return new Sis_Pdv_Controle_Estoque.Commands.Response(this);
+                return new Commands.Response(this);
             }
 
             departamento = _repositoryDepartamento.Editar(departamento);
@@ -38,7 +38,7 @@ namespace Commands.Departamento.AlterarDepartamento
             var result = new { Id = departamento.Id, NomeDepartamento = departamento.NomeDepartamento };
 
             //Criar meu objeto de resposta
-            var response = new Sis_Pdv_Controle_Estoque.Commands.Response(this, result);
+            var response = new Commands.Response(this, result);
 
             return await Task.FromResult(response);
         }

--- a/Sis-Pdv-Controle-Estoque/Commands/Departamento/AlterarDepartamento/AlterarDepartamentoRequest.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Departamento/AlterarDepartamento/AlterarDepartamentoRequest.cs
@@ -2,7 +2,7 @@
 
 namespace Commands.Departamento.AlterarDepartamento
 {
-    public class AlterarDepartamentoRequest : IRequest<Sis_Pdv_Controle_Estoque.Commands.Response>
+    public class AlterarDepartamentoRequest : IRequest<Commands.Response>
     {
         public Guid Id { get; set; }
         public string NomeDepartamento { get; set; }

--- a/Sis-Pdv-Controle-Estoque/Commands/Departamento/ListarDepartamento/ListarDepartamentoHandler.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Departamento/ListarDepartamento/ListarDepartamentoHandler.cs
@@ -3,7 +3,7 @@ using prmToolkit.NotificationPattern;
 
 namespace Commands.Departamento.ListarDepartamento
 {
-    public class ListarDepartamentoPorIdHandler : Notifiable, IRequestHandler<ListarDepartamentoRequest, Sis_Pdv_Controle_Estoque.Commands.Response>
+    public class ListarDepartamentoPorIdHandler : Notifiable, IRequestHandler<ListarDepartamentoRequest, Commands.Response>
     {
         private readonly IMediator _mediator;
         private readonly IRepositoryDepartamento _repositoryDepartamento;
@@ -14,20 +14,20 @@ namespace Commands.Departamento.ListarDepartamento
             _repositoryDepartamento = repositoryDepartamento;
         }
 
-        public async Task<Sis_Pdv_Controle_Estoque.Commands.Response> Handle(ListarDepartamentoRequest request, CancellationToken cancellationToken)
+        public async Task<Commands.Response> Handle(ListarDepartamentoRequest request, CancellationToken cancellationToken)
         {
             //Valida se o objeto request esta nulo
             if (request == null)
             {
                 AddNotification("Request", "");
-                return new Sis_Pdv_Controle_Estoque.Commands.Response(this);
+                return new Commands.Response(this);
             }
 
             var grupoCollection = _repositoryDepartamento.Listar().ToList();
 
 
             //Cria objeto de resposta
-            var response = new Sis_Pdv_Controle_Estoque.Commands.Response(this, grupoCollection);
+            var response = new Commands.Response(this, grupoCollection);
 
             ////Retorna o resultado
             return await Task.FromResult(response);

--- a/Sis-Pdv-Controle-Estoque/Commands/Departamento/ListarDepartamento/ListarDepartamentoRequest.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Departamento/ListarDepartamento/ListarDepartamentoRequest.cs
@@ -2,7 +2,7 @@
 
 namespace Commands.Departamento.ListarDepartamento
 {
-    public class ListarDepartamentoRequest : IRequest<Sis_Pdv_Controle_Estoque.Commands.Response>
+    public class ListarDepartamentoRequest : IRequest<Commands.Response>
     {
     }
 }

--- a/Sis-Pdv-Controle-Estoque/Commands/Departamento/ListarDepartamentoPorId/ListarDepartamentoPorIdHandler.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Departamento/ListarDepartamentoPorId/ListarDepartamentoPorIdHandler.cs
@@ -23,7 +23,7 @@ namespace Commands.Departamento.ListarDepartamentoPorId
                 return null;
             }
 
-            Sis_Pdv_Controle_Estoque.Model.Departamento Collection = _repositoryDepartamento.ObterPor(x => x.Id == request.Id);
+            Model.Departamento Collection = _repositoryDepartamento.ObterPor(x => x.Id == request.Id);
 
             if (Collection == null)
             {

--- a/Sis-Pdv-Controle-Estoque/Commands/Departamento/ListarDepartamentoPorId/ListarDepartamentoPorIdResponse.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Departamento/ListarDepartamentoPorId/ListarDepartamentoPorIdResponse.cs
@@ -5,7 +5,7 @@
         public Guid? Id { get; set; }
         public string NomeDepartamento { get; set; }
 
-        public static explicit operator ListarDepartamentoPorIdResponse(Sis_Pdv_Controle_Estoque.Model.Departamento cat)
+        public static explicit operator ListarDepartamentoPorIdResponse(Model.Departamento cat)
         {
             return new ListarDepartamentoPorIdResponse()
             {

--- a/Sis-Pdv-Controle-Estoque/Commands/Departamento/RemoverDepartamento/RemoverCategoriaHandler.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Departamento/RemoverDepartamento/RemoverCategoriaHandler.cs
@@ -4,7 +4,7 @@ using prmToolkit.NotificationPattern;
 namespace Commands.Departamento.RemoverDepartamento
 
 {
-    public class RemoverDepartamentoHandler : Notifiable, IRequestHandler<RemoverDepartamentoResquest, Sis_Pdv_Controle_Estoque.Commands.Response>
+    public class RemoverDepartamentoHandler : Notifiable, IRequestHandler<RemoverDepartamentoResquest, Commands.Response>
     {
         private readonly IMediator _mediator;
         private readonly IRepositoryDepartamento _repositoryDepartamento;
@@ -15,21 +15,21 @@ namespace Commands.Departamento.RemoverDepartamento
             _repositoryDepartamento = repositoryDepartamento;
         }
 
-        public async Task<Sis_Pdv_Controle_Estoque.Commands.Response> Handle(RemoverDepartamentoResquest request, CancellationToken cancellationToken)
+        public async Task<Commands.Response> Handle(RemoverDepartamentoResquest request, CancellationToken cancellationToken)
         {
             //Valida se o objeto request esta nulo
             if (request == null)
             {
                 AddNotification("Request", "");
-                return new Sis_Pdv_Controle_Estoque.Commands.Response(this);
+                return new Commands.Response(this);
             }
 
-            Sis_Pdv_Controle_Estoque.Model.Departamento Departamento = _repositoryDepartamento.ObterPorId(request.Id);
+            Model.Departamento Departamento = _repositoryDepartamento.ObterPorId(request.Id);
 
             if (Departamento == null)
             {
                 AddNotification("Request", "");
-                return new Sis_Pdv_Controle_Estoque.Commands.Response(this);
+                return new Commands.Response(this);
             }
 
             _repositoryDepartamento.Remover(Departamento);
@@ -37,7 +37,7 @@ namespace Commands.Departamento.RemoverDepartamento
             var result = new { Id = Departamento.Id };
 
             //Cria objeto de resposta
-            var response = new Sis_Pdv_Controle_Estoque.Commands.Response(this, result);
+            var response = new Commands.Response(this, result);
 
             ////Retorna o resultado
             return await Task.FromResult(response);

--- a/Sis-Pdv-Controle-Estoque/Commands/Fornecedor/AlterarFornecedor/AlterarFornecedorHandler.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Fornecedor/AlterarFornecedor/AlterarFornecedorHandler.cs
@@ -33,7 +33,7 @@ namespace Commands.Fornecedor.AlterarFornecedor
                 return new Response(this);
             }
 
-            Sis_Pdv_Controle_Estoque.Model.Fornecedor Fornecedor = new Sis_Pdv_Controle_Estoque.Model.Fornecedor();
+            Model.Fornecedor Fornecedor = new Model.Fornecedor();
 
             Fornecedor.AlterarFornecedor(request.Id, request.inscricaoEstadual, request.nomeFantasia, request.Uf, request.Numero,
             request.Complemento, request.Bairro, request.Cidade, request.cepFornecedor, request.statusAtivo, request.Cnpj, request.Rua);

--- a/Sis-Pdv-Controle-Estoque/Commands/Fornecedor/ListarFornecedor/ListarFornecedorHandler.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Fornecedor/ListarFornecedor/ListarFornecedorHandler.cs
@@ -3,7 +3,7 @@ using prmToolkit.NotificationPattern;
 
 namespace Commands.Fornecedor.ListarFornecedor
 {
-    public class ListarFornecedorPorIdHandler : Notifiable, IRequestHandler<ListarFornecedorRequest, Sis_Pdv_Controle_Estoque.Commands.Response>
+    public class ListarFornecedorPorIdHandler : Notifiable, IRequestHandler<ListarFornecedorRequest, Commands.Response>
     {
         private readonly IMediator _mediator;
         private readonly IRepositoryFornecedor _repositoryFornecedor;
@@ -14,20 +14,20 @@ namespace Commands.Fornecedor.ListarFornecedor
             _repositoryFornecedor = repositoryFornecedor;
         }
 
-        public async Task<Sis_Pdv_Controle_Estoque.Commands.Response> Handle(ListarFornecedorRequest request, CancellationToken cancellationToken)
+        public async Task<Commands.Response> Handle(ListarFornecedorRequest request, CancellationToken cancellationToken)
         {
             //Valida se o objeto request esta nulo
             if (request == null)
             {
                 AddNotification("Request", "");
-                return new Sis_Pdv_Controle_Estoque.Commands.Response(this);
+                return new Commands.Response(this);
             }
 
             var grupoCollection = _repositoryFornecedor.Listar().ToList();
 
 
             //Cria objeto de resposta
-            var response = new Sis_Pdv_Controle_Estoque.Commands.Response(this, grupoCollection);
+            var response = new Commands.Response(this, grupoCollection);
 
             ////Retorna o resultado
             return await Task.FromResult(response);

--- a/Sis-Pdv-Controle-Estoque/Commands/Fornecedor/ListarFornecedor/ListarFornecedorRequest.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Fornecedor/ListarFornecedor/ListarFornecedorRequest.cs
@@ -2,7 +2,7 @@
 
 namespace Commands.Fornecedor.ListarFornecedor
 {
-    public class ListarFornecedorRequest : IRequest<Sis_Pdv_Controle_Estoque.Commands.Response>
+    public class ListarFornecedorRequest : IRequest<Commands.Response>
     {
     }
 }

--- a/Sis-Pdv-Controle-Estoque/Commands/Fornecedor/ListarFornecedorPorId/ListarFornecedorPorIdHandler.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Fornecedor/ListarFornecedorPorId/ListarFornecedorPorIdHandler.cs
@@ -23,7 +23,7 @@ namespace Commands.Fornecedor.ListarFornecedorPorId
                 return null;
             }
 
-            Sis_Pdv_Controle_Estoque.Model.Fornecedor Collection = _repositoryFornecedor.ObterPor(x => x.Id == request.Id);
+            Model.Fornecedor Collection = _repositoryFornecedor.ObterPor(x => x.Id == request.Id);
 
             if (Collection == null)
             {

--- a/Sis-Pdv-Controle-Estoque/Commands/Fornecedor/ListarFornecedorPorId/ListarFornecedorPorIdResponse.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Fornecedor/ListarFornecedorPorId/ListarFornecedorPorIdResponse.cs
@@ -15,7 +15,7 @@
         public string Cnpj { get; set; }
         public string Rua { get; set; }
 
-        public static explicit operator ListarFornecedorPorIdResponse(Sis_Pdv_Controle_Estoque.Model.Fornecedor request)
+        public static explicit operator ListarFornecedorPorIdResponse(Model.Fornecedor request)
         {
             return new ListarFornecedorPorIdResponse()
             {

--- a/Sis-Pdv-Controle-Estoque/Commands/Fornecedor/RemoverFornecedor/RemoverFornecedorHandler.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Fornecedor/RemoverFornecedor/RemoverFornecedorHandler.cs
@@ -4,7 +4,7 @@ using prmToolkit.NotificationPattern;
 namespace Commands.Fornecedor.RemoverFornecedor
 
 {
-    public class RemoverFornecedorHandler : Notifiable, IRequestHandler<RemoverFornecedorResquest, Sis_Pdv_Controle_Estoque.Commands.Response>
+    public class RemoverFornecedorHandler : Notifiable, IRequestHandler<RemoverFornecedorResquest, Commands.Response>
     {
         private readonly IMediator _mediator;
         private readonly IRepositoryFornecedor _repositoryFornecedor;
@@ -15,21 +15,21 @@ namespace Commands.Fornecedor.RemoverFornecedor
             _repositoryFornecedor = repositoryFornecedor;
         }
 
-        public async Task<Sis_Pdv_Controle_Estoque.Commands.Response> Handle(RemoverFornecedorResquest request, CancellationToken cancellationToken)
+        public async Task<Commands.Response> Handle(RemoverFornecedorResquest request, CancellationToken cancellationToken)
         {
             //Valida se o objeto request esta nulo
             if (request == null)
             {
                 AddNotification("Request", "");
-                return new Sis_Pdv_Controle_Estoque.Commands.Response(this);
+                return new Commands.Response(this);
             }
 
-            Sis_Pdv_Controle_Estoque.Model.Fornecedor Fornecedor = _repositoryFornecedor.ObterPorId(request.Id);
+            Model.Fornecedor Fornecedor = _repositoryFornecedor.ObterPorId(request.Id);
 
             if (Fornecedor == null)
             {
                 AddNotification("Request", "");
-                return new Sis_Pdv_Controle_Estoque.Commands.Response(this);
+                return new Commands.Response(this);
             }
 
             _repositoryFornecedor.Remover(Fornecedor);
@@ -37,7 +37,7 @@ namespace Commands.Fornecedor.RemoverFornecedor
             var result = new { Id = Fornecedor.Id };
 
             //Cria objeto de resposta
-            var response = new Sis_Pdv_Controle_Estoque.Commands.Response(this, result);
+            var response = new Commands.Response(this, result);
 
             ////Retorna o resultado
             return await Task.FromResult(response);

--- a/Sis-Pdv-Controle-Estoque/Commands/Pedidos/AlterarPedido/AlterarPedidoHandler.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Pedidos/AlterarPedido/AlterarPedidoHandler.cs
@@ -33,7 +33,7 @@ namespace Commands.Pedidos.AlterarPedido
                 return new Response(this);
             }
 
-            Sis_Pdv_Controle_Estoque.Model.Pedido Pedido = new Sis_Pdv_Controle_Estoque.Model.Pedido();
+            Model.Pedido Pedido = new Model.Pedido();
 
             Pedido.AlterarPedido(request.ColaboradorId,
                                         request.ClienteId,

--- a/Sis-Pdv-Controle-Estoque/Commands/Pedidos/AlterarPedido/AlterarPedidoRequest.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Pedidos/AlterarPedido/AlterarPedidoRequest.cs
@@ -2,7 +2,7 @@
 
 namespace Commands.Pedidos.AlterarPedido
 {
-    public class AlterarPedidoRequest : IRequest<Sis_Pdv_Controle_Estoque.Commands.Response>
+    public class AlterarPedidoRequest : IRequest<Commands.Response>
     {
         public Guid Id { get; set; }
         public Guid ColaboradorId { get; set; }

--- a/Sis-Pdv-Controle-Estoque/Commands/Pedidos/ListarPedido/ListarPedidoHandler.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Pedidos/ListarPedido/ListarPedidoHandler.cs
@@ -4,7 +4,7 @@ using prmToolkit.NotificationPattern;
 
 namespace Commands.Pedidos.ListarPedido
 {
-    public class ListarPedidoPorIdHandler : Notifiable, IRequestHandler<ListarPedidoRequest, Sis_Pdv_Controle_Estoque.Commands.Response>
+    public class ListarPedidoPorIdHandler : Notifiable, IRequestHandler<ListarPedidoRequest, Commands.Response>
     {
         private readonly IMediator _mediator;
         private readonly IRepositoryPedido _repositoryPedido;
@@ -15,20 +15,20 @@ namespace Commands.Pedidos.ListarPedido
             _repositoryPedido = repositoryPedido;
         }
 
-        public async Task<Sis_Pdv_Controle_Estoque.Commands.Response> Handle(ListarPedidoRequest request, CancellationToken cancellationToken)
+        public async Task<Commands.Response> Handle(ListarPedidoRequest request, CancellationToken cancellationToken)
         {
             //Valida se o objeto request esta nulo
             if (request == null)
             {
                 AddNotification("Request", "");
-                return new Sis_Pdv_Controle_Estoque.Commands.Response(this);
+                return new Commands.Response(this);
             }
 
             var grupoCollection = _repositoryPedido.Listar().Include(x => x.Colaborador).ToList();
 
 
             //Cria objeto de resposta
-            var response = new Sis_Pdv_Controle_Estoque.Commands.Response(this, grupoCollection);
+            var response = new Commands.Response(this, grupoCollection);
 
             ////Retorna o resultado
             return await Task.FromResult(response);

--- a/Sis-Pdv-Controle-Estoque/Commands/Pedidos/ListarPedido/ListarPedidoRequest.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Pedidos/ListarPedido/ListarPedidoRequest.cs
@@ -2,7 +2,7 @@
 
 namespace Commands.Pedidos.ListarPedido
 {
-    public class ListarPedidoRequest : IRequest<Sis_Pdv_Controle_Estoque.Commands.Response>
+    public class ListarPedidoRequest : IRequest<Commands.Response>
     {
     }
 }

--- a/Sis-Pdv-Controle-Estoque/Commands/Pedidos/ListarPedidoPorNomeCpfCnpj/ListarPedidoPorNomeCpfCnpjHandler.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Pedidos/ListarPedidoPorNomeCpfCnpj/ListarPedidoPorNomeCpfCnpjHandler.cs
@@ -4,7 +4,7 @@ using prmToolkit.NotificationPattern;
 
 namespace Commands.Pedidos.ListarPedidoPorNomeCpfCnpj
 {
-    public class ListarPedidoPorNomeCpfCnpjHandler : Notifiable, IRequestHandler<ListarPedidoPorNomeCpfCnpjRequest, Sis_Pdv_Controle_Estoque.Commands.Response>
+    public class ListarPedidoPorNomeCpfCnpjHandler : Notifiable, IRequestHandler<ListarPedidoPorNomeCpfCnpjRequest, Commands.Response>
     {
         private readonly IMediator _mediator;
         private readonly IRepositoryPedido _repositoryPedido;
@@ -15,13 +15,13 @@ namespace Commands.Pedidos.ListarPedidoPorNomeCpfCnpj
             _repositoryPedido = repositoryPedido;
         }
 
-        public async Task<Sis_Pdv_Controle_Estoque.Commands.Response> Handle(ListarPedidoPorNomeCpfCnpjRequest request, CancellationToken cancellationToken)
+        public async Task<Commands.Response> Handle(ListarPedidoPorNomeCpfCnpjRequest request, CancellationToken cancellationToken)
         {
             //Valida se o objeto request esta nulo
             if (request == null)
             {
                 AddNotification("Erro", "Handle");
-                return new Sis_Pdv_Controle_Estoque.Commands.Response(this);
+                return new Commands.Response(this);
             }
 
             var Collection = _repositoryPedido.Listar()
@@ -31,11 +31,11 @@ namespace Commands.Pedidos.ListarPedidoPorNomeCpfCnpj
             if (!Collection.Any())
             {
                 AddNotification("ATENÇÃO", "Pedido NÃO ENCONTRADA");
-                return new Sis_Pdv_Controle_Estoque.Commands.Response(this);
+                return new Commands.Response(this);
             }
 
             //Criar meu objeto de resposta
-            var response = new Sis_Pdv_Controle_Estoque.Commands.Response(this, Collection);
+            var response = new Commands.Response(this, Collection);
             //Cria objeto de resposta
 
             ////Retorna o resultado

--- a/Sis-Pdv-Controle-Estoque/Commands/Pedidos/ListarPedidoPorNomeCpfCnpj/ListarPedidoPorNomeCpfCnpjRequest.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Pedidos/ListarPedidoPorNomeCpfCnpj/ListarPedidoPorNomeCpfCnpjRequest.cs
@@ -2,7 +2,7 @@
 
 namespace Commands.Pedidos.ListarPedidoPorNomeCpfCnpj
 {
-    public class ListarPedidoPorNomeCpfCnpjRequest : IRequest<Sis_Pdv_Controle_Estoque.Commands.Response>
+    public class ListarPedidoPorNomeCpfCnpjRequest : IRequest<Commands.Response>
     {
         public ListarPedidoPorNomeCpfCnpjRequest(string cnpj)
         {

--- a/Sis-Pdv-Controle-Estoque/Commands/Pedidos/ListarPedidorPorId/ListarPedidorPorIdHandler.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Pedidos/ListarPedidorPorId/ListarPedidorPorIdHandler.cs
@@ -3,7 +3,7 @@ using prmToolkit.NotificationPattern;
 
 namespace Commands.Pedidos.ListarPedidorPorId
 {
-    public class ListarPedidoPorIdHandler : Notifiable, IRequestHandler<ListarPedidoPorIdRequest, Sis_Pdv_Controle_Estoque.Commands.Response>
+    public class ListarPedidoPorIdHandler : Notifiable, IRequestHandler<ListarPedidoPorIdRequest, Commands.Response>
     {
         private readonly IMediator _mediator;
         private readonly IRepositoryPedido _repositoryPedido;
@@ -14,25 +14,25 @@ namespace Commands.Pedidos.ListarPedidorPorId
             _repositoryPedido = repositoryPedido;
         }
 
-        public async Task<Sis_Pdv_Controle_Estoque.Commands.Response> Handle(ListarPedidoPorIdRequest request, CancellationToken cancellationToken)
+        public async Task<Commands.Response> Handle(ListarPedidoPorIdRequest request, CancellationToken cancellationToken)
         {
             //Valida se o objeto request esta nulo
             if (request == null)
             {
                 AddNotification("Request", "");
-                return new Sis_Pdv_Controle_Estoque.Commands.Response(this);
+                return new Commands.Response(this);
             }
 
-            Sis_Pdv_Controle_Estoque.Model.Pedido Collection = _repositoryPedido.ListarPor(x => x.Id == request.Id).FirstOrDefault();
+            Model.Pedido Collection = _repositoryPedido.ListarPor(x => x.Id == request.Id).FirstOrDefault();
 
             if (Collection == null)
             {
                 AddNotification("Request", "");
-                return new Sis_Pdv_Controle_Estoque.Commands.Response(this);
+                return new Commands.Response(this);
             }
 
             //Cria objeto de resposta
-            var response = new Sis_Pdv_Controle_Estoque.Commands.Response(this, Collection);
+            var response = new Commands.Response(this, Collection);
 
             ////Retorna o resultado
             return await Task.FromResult(response);

--- a/Sis-Pdv-Controle-Estoque/Commands/Pedidos/ListarPedidorPorId/ListarPedidorPorIdRequest.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Pedidos/ListarPedidorPorId/ListarPedidorPorIdRequest.cs
@@ -2,7 +2,7 @@
 
 namespace Commands.Pedidos.ListarPedidorPorId
 {
-    public class ListarPedidoPorIdRequest : IRequest<Sis_Pdv_Controle_Estoque.Commands.Response>
+    public class ListarPedidoPorIdRequest : IRequest<Commands.Response>
     {
         public ListarPedidoPorIdRequest(Guid? id)
         {

--- a/Sis-Pdv-Controle-Estoque/Commands/Pedidos/ListarVendaPedidoPorData/ListarVendaPedidoPorDataHandler.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Pedidos/ListarVendaPedidoPorData/ListarVendaPedidoPorDataHandler.cs
@@ -3,7 +3,7 @@ using prmToolkit.NotificationPattern;
 
 namespace Commands.Pedidos.ListarVendaPedidoPorData
 {
-    public class ListarVendaPedidoPorDataHandler : Notifiable, IRequestHandler<ListarVendaPedidoPorDataRequest, Sis_Pdv_Controle_Estoque.Commands.Response>
+    public class ListarVendaPedidoPorDataHandler : Notifiable, IRequestHandler<ListarVendaPedidoPorDataRequest, Commands.Response>
     {
         private readonly IMediator _mediator;
         private readonly IRepositoryPedido _repositoryPedido;
@@ -14,13 +14,13 @@ namespace Commands.Pedidos.ListarVendaPedidoPorData
             _repositoryPedido = repositoryPedido;
         }
 
-        public async Task<Sis_Pdv_Controle_Estoque.Commands.Response> Handle(ListarVendaPedidoPorDataRequest request, CancellationToken cancellationToken)
+        public async Task<Commands.Response> Handle(ListarVendaPedidoPorDataRequest request, CancellationToken cancellationToken)
         {
             //Valida se o objeto request esta nulo
             if (request == null)
             {
                 AddNotification("Erro", "Handle");
-                return new Sis_Pdv_Controle_Estoque.Commands.Response(this);
+                return new Commands.Response(this);
             }
 
             var Collection = _repositoryPedido.ListarVendaPedidoPorData(request.DataInicio, request.DataFim);
@@ -28,11 +28,11 @@ namespace Commands.Pedidos.ListarVendaPedidoPorData
             if (!Collection.Result.Any())
             {
                 AddNotification("ATENÇÃO", "Pedido NÃO ENCONTRADA");
-                return new Sis_Pdv_Controle_Estoque.Commands.Response(this);
+                return new Commands.Response(this);
             }
 
             //Criar meu objeto de resposta
-            var response = new Sis_Pdv_Controle_Estoque.Commands.Response(this, Collection.Result);
+            var response = new Commands.Response(this, Collection.Result);
             //Cria objeto de resposta
 
             ////Retorna o resultado

--- a/Sis-Pdv-Controle-Estoque/Commands/Pedidos/ListarVendaPedidoPorData/ListarVendaPedidoPorDataRequest.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Pedidos/ListarVendaPedidoPorData/ListarVendaPedidoPorDataRequest.cs
@@ -2,7 +2,7 @@
 
 namespace Commands.Pedidos.ListarVendaPedidoPorData
 {
-    public class ListarVendaPedidoPorDataRequest : IRequest<Sis_Pdv_Controle_Estoque.Commands.Response>
+    public class ListarVendaPedidoPorDataRequest : IRequest<Commands.Response>
     {
         public ListarVendaPedidoPorDataRequest(DateTime dataInicio, DateTime dataFim)
         {

--- a/Sis-Pdv-Controle-Estoque/Commands/Pedidos/RemoverPedido/RemoverPedidorHandler.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Pedidos/RemoverPedido/RemoverPedidorHandler.cs
@@ -4,7 +4,7 @@ using prmToolkit.NotificationPattern;
 namespace Commands.Pedidos.RemoverPedido
 
 {
-    public class RemoverPedidoHandler : Notifiable, IRequestHandler<RemoverPedidoResquest, Sis_Pdv_Controle_Estoque.Commands.Response>
+    public class RemoverPedidoHandler : Notifiable, IRequestHandler<RemoverPedidoResquest, Commands.Response>
     {
         private readonly IMediator _mediator;
         private readonly IRepositoryPedido _repositoryPedido;
@@ -15,21 +15,21 @@ namespace Commands.Pedidos.RemoverPedido
             _repositoryPedido = repositoryPedido;
         }
 
-        public async Task<Sis_Pdv_Controle_Estoque.Commands.Response> Handle(RemoverPedidoResquest request, CancellationToken cancellationToken)
+        public async Task<Commands.Response> Handle(RemoverPedidoResquest request, CancellationToken cancellationToken)
         {
             //Valida se o objeto request esta nulo
             if (request == null)
             {
                 AddNotification("Request", "");
-                return new Sis_Pdv_Controle_Estoque.Commands.Response(this);
+                return new Commands.Response(this);
             }
 
-            Sis_Pdv_Controle_Estoque.Model.Pedido Pedido = _repositoryPedido.ObterPorId(request.Id);
+            Model.Pedido Pedido = _repositoryPedido.ObterPorId(request.Id);
 
             if (Pedido == null)
             {
                 AddNotification("Request", "");
-                return new Sis_Pdv_Controle_Estoque.Commands.Response(this);
+                return new Commands.Response(this);
             }
 
             _repositoryPedido.Remover(Pedido);
@@ -37,7 +37,7 @@ namespace Commands.Pedidos.RemoverPedido
             var result = new { Pedido.Id };
 
             //Cria objeto de resposta
-            var response = new Sis_Pdv_Controle_Estoque.Commands.Response(this, result);
+            var response = new Commands.Response(this, result);
 
             ////Retorna o resultado
             return await Task.FromResult(response);

--- a/Sis-Pdv-Controle-Estoque/Commands/Produto/AlterarProduto/AlterarProdutoHandler.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Produto/AlterarProduto/AlterarProdutoHandler.cs
@@ -33,7 +33,7 @@ namespace Commands.Produto.AlterarProduto
                 return new Response(this);
             }
 
-            Sis_Pdv_Controle_Estoque.Model.Produto Produto = new Sis_Pdv_Controle_Estoque.Model.Produto();
+            Model.Produto Produto = new Model.Produto();
 
             Produto.AlterarProduto(
                 request.Id,

--- a/Sis-Pdv-Controle-Estoque/Commands/Produto/AtualizarEstoque/AtualizarEstoqueHandler.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Produto/AtualizarEstoque/AtualizarEstoqueHandler.cs
@@ -33,7 +33,7 @@ namespace Commands.Produto.AtualizarEstoque
                 return new Response(this);
             }
 
-            Sis_Pdv_Controle_Estoque.Model.Produto Produto = new Sis_Pdv_Controle_Estoque.Model.Produto();
+            Model.Produto Produto = new Model.Produto();
 
             var retornoExist = _repositoryProduto.Listar().Where(x => x.Id == request.Id).FirstOrDefault();
 

--- a/Sis-Pdv-Controle-Estoque/Commands/Produto/ListarProduto/ListarProdutoHandler.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Produto/ListarProduto/ListarProdutoHandler.cs
@@ -4,7 +4,7 @@ using prmToolkit.NotificationPattern;
 
 namespace Commands.Produto.ListarProduto
 {
-    public class ListarProdutoPorIdHandler : Notifiable, IRequestHandler<ListarProdutoRequest, Sis_Pdv_Controle_Estoque.Commands.Response>
+    public class ListarProdutoPorIdHandler : Notifiable, IRequestHandler<ListarProdutoRequest, Commands.Response>
     {
         private readonly IMediator _mediator;
         private readonly IRepositoryProduto _repositoryProduto;
@@ -15,13 +15,13 @@ namespace Commands.Produto.ListarProduto
             _repositoryProduto = repositoryProduto;
         }
 
-        public async Task<Sis_Pdv_Controle_Estoque.Commands.Response> Handle(ListarProdutoRequest request, CancellationToken cancellationToken)
+        public async Task<Commands.Response> Handle(ListarProdutoRequest request, CancellationToken cancellationToken)
         {
             //Valida se o objeto request esta nulo
             if (request == null)
             {
                 AddNotification("Request", "");
-                return new Sis_Pdv_Controle_Estoque.Commands.Response(this);
+                return new Commands.Response(this);
             }
 
             var _produto = _repositoryProduto.Listar().Include(x => x.Fornecedor).Include(x => x.Categoria).ToList();
@@ -51,7 +51,7 @@ namespace Commands.Produto.ListarProduto
             //var result = new { Id = _produto., NomeProduto = _produto.NomeProduto};
 
             //Cria objeto de resposta
-            var response = new Sis_Pdv_Controle_Estoque.Commands.Response(this, _lista);
+            var response = new Commands.Response(this, _lista);
 
             ////Retorna o resultado
             return await Task.FromResult(response);

--- a/Sis-Pdv-Controle-Estoque/Commands/Produto/ListarProduto/ListarProdutoRequest.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Produto/ListarProduto/ListarProdutoRequest.cs
@@ -2,7 +2,7 @@
 
 namespace Commands.Produto.ListarProduto
 {
-    public class ListarProdutoRequest : IRequest<Sis_Pdv_Controle_Estoque.Commands.Response>
+    public class ListarProdutoRequest : IRequest<Commands.Response>
     {
         public Guid? Id { get; set; }
         public string codBarras { get; set; }

--- a/Sis-Pdv-Controle-Estoque/Commands/Produto/ListarProdutoPorId/ListarProdutoPorIdHandler.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Produto/ListarProdutoPorId/ListarProdutoPorIdHandler.cs
@@ -23,7 +23,7 @@ namespace Commands.Produto.ListarProdutoPorId
                 return new ListarProdutoPorIdResponse();
             }
 
-            Sis_Pdv_Controle_Estoque.Model.Produto Collection = _repositoryProduto.ObterPor(x => x.Id == request.Id);
+            Model.Produto Collection = _repositoryProduto.ObterPor(x => x.Id == request.Id);
 
             if (Collection == null)
             {

--- a/Sis-Pdv-Controle-Estoque/Commands/Produto/ListarProdutoPorId/ListarProdutoPorIdResponse.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Produto/ListarProdutoPorId/ListarProdutoPorIdResponse.cs
@@ -12,11 +12,11 @@
         public DateTime dataFabricao { get; set; }
         public DateTime dataVencimento { get; set; }
         public int quatidadeEstoqueProduto { get; set; }
-        public Sis_Pdv_Controle_Estoque.Model.Fornecedor Fornecedor { get; set; }
-        public Sis_Pdv_Controle_Estoque.Model.Categoria Categoria { get; set; }
+        public Model.Fornecedor Fornecedor { get; set; }
+        public Model.Categoria Categoria { get; set; }
         public int statusAtivo { get; set; }
 
-        public static explicit operator ListarProdutoPorIdResponse(Sis_Pdv_Controle_Estoque.Model.Produto request)
+        public static explicit operator ListarProdutoPorIdResponse(Model.Produto request)
         {
             return new ListarProdutoPorIdResponse()
             {
@@ -29,8 +29,8 @@
                 dataFabricao = request.dataFabricao,
                 dataVencimento = request.dataVencimento,
                 quatidadeEstoqueProduto = request.quatidadeEstoqueProduto,
-                Fornecedor = new Sis_Pdv_Controle_Estoque.Model.Fornecedor { Id = request.Id },
-                Categoria = new Sis_Pdv_Controle_Estoque.Model.Categoria { Id = request.Id },
+                Fornecedor = new Model.Fornecedor { Id = request.Id },
+                Categoria = new Model.Categoria { Id = request.Id },
                 statusAtivo = request.statusAtivo
             };
         }

--- a/Sis-Pdv-Controle-Estoque/Commands/Produto/ListarProdutoPorNomeProduto/ListarProdutoPorCodBarrasHandler.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Produto/ListarProdutoPorNomeProduto/ListarProdutoPorCodBarrasHandler.cs
@@ -3,7 +3,7 @@ using prmToolkit.NotificationPattern;
 
 namespace Commands.Produto.ListarProdutoPorNomeProduto
 {
-    public class ListarProdutoPorCodBarrasHandler : Notifiable, IRequestHandler<ListarProdutoPorCodBarrasRequest, Sis_Pdv_Controle_Estoque.Commands.Response>
+    public class ListarProdutoPorCodBarrasHandler : Notifiable, IRequestHandler<ListarProdutoPorCodBarrasRequest, Commands.Response>
     {
         private readonly IMediator _mediator;
         private readonly IRepositoryProduto _repositoryProduto;
@@ -14,24 +14,24 @@ namespace Commands.Produto.ListarProdutoPorNomeProduto
             _repositoryProduto = repositoryProduto;
         }
 
-        public async Task<Sis_Pdv_Controle_Estoque.Commands.Response> Handle(ListarProdutoPorCodBarrasRequest request, CancellationToken cancellationToken)
+        public async Task<Commands.Response> Handle(ListarProdutoPorCodBarrasRequest request, CancellationToken cancellationToken)
         {
             //Valida se o objeto request esta nulo
             if (request == null)
             {
                 AddNotification("Erro", "Handle");
-                return new Sis_Pdv_Controle_Estoque.Commands.Response(this);
+                return new Commands.Response(this);
             }
 
             var Collection = _repositoryProduto.Listar().Where(x => x.codBarras == request.codBarras);
             if (!Collection.Any())
             {
                 AddNotification("ATENÇÃO", "PRODUTO NÃO ENCONTRADA");
-                return new Sis_Pdv_Controle_Estoque.Commands.Response(this);
+                return new Commands.Response(this);
             }
 
             //Criar meu objeto de resposta
-            var response = new Sis_Pdv_Controle_Estoque.Commands.Response(this, Collection);
+            var response = new Commands.Response(this, Collection);
             //Cria objeto de resposta
 
             ////Retorna o resultado

--- a/Sis-Pdv-Controle-Estoque/Commands/Produto/ListarProdutoPorNomeProduto/ListarProdutoPorCodBarrasRequest.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Produto/ListarProdutoPorNomeProduto/ListarProdutoPorCodBarrasRequest.cs
@@ -2,7 +2,7 @@
 
 namespace Commands.Produto.ListarProdutoPorNomeProduto
 {
-    public class ListarProdutoPorCodBarrasRequest : IRequest<Sis_Pdv_Controle_Estoque.Commands.Response>
+    public class ListarProdutoPorCodBarrasRequest : IRequest<Commands.Response>
     {
         public ListarProdutoPorCodBarrasRequest(string codBarras)
         {

--- a/Sis-Pdv-Controle-Estoque/Commands/Produto/RemoverProduto/RemoverProdutoHandler.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/Produto/RemoverProduto/RemoverProdutoHandler.cs
@@ -4,7 +4,7 @@ using prmToolkit.NotificationPattern;
 namespace Commands.Produto.RemoverProduto
 
 {
-    public class RemoverProdutoHandler : Notifiable, IRequestHandler<RemoverProdutoResquest, Sis_Pdv_Controle_Estoque.Commands.Response>
+    public class RemoverProdutoHandler : Notifiable, IRequestHandler<RemoverProdutoResquest, Commands.Response>
     {
         private readonly IMediator _mediator;
         private readonly IRepositoryProduto _repositoryProduto;
@@ -15,21 +15,21 @@ namespace Commands.Produto.RemoverProduto
             _repositoryProduto = repositoryProduto;
         }
 
-        public async Task<Sis_Pdv_Controle_Estoque.Commands.Response> Handle(RemoverProdutoResquest request, CancellationToken cancellationToken)
+        public async Task<Commands.Response> Handle(RemoverProdutoResquest request, CancellationToken cancellationToken)
         {
             //Valida se o objeto request esta nulo
             if (request == null)
             {
                 AddNotification("Request", "");
-                return new Sis_Pdv_Controle_Estoque.Commands.Response(this);
+                return new Commands.Response(this);
             }
 
-            Sis_Pdv_Controle_Estoque.Model.Produto Produto = _repositoryProduto.ObterPorId(request.Id);
+            Model.Produto Produto = _repositoryProduto.ObterPorId(request.Id);
 
             if (Produto == null)
             {
                 AddNotification("Request", "");
-                return new Sis_Pdv_Controle_Estoque.Commands.Response(this);
+                return new Commands.Response(this);
             }
 
             _repositoryProduto.Remover(Produto);
@@ -37,7 +37,7 @@ namespace Commands.Produto.RemoverProduto
             var result = new { Id = Produto.Id };
 
             //Cria objeto de resposta
-            var response = new Sis_Pdv_Controle_Estoque.Commands.Response(this, result);
+            var response = new Commands.Response(this, result);
 
             ////Retorna o resultado
             return await Task.FromResult(response);

--- a/Sis-Pdv-Controle-Estoque/Commands/ProdutoPedido/AlterarProdutoPedido/AlterarProdutoPedidoHandler.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/ProdutoPedido/AlterarProdutoPedido/AlterarProdutoPedidoHandler.cs
@@ -33,7 +33,7 @@ namespace Commands.ProdutoPedido.AlterarProdutoPedido
                 return new Response(this);
             }
 
-            Sis_Pdv_Controle_Estoque.Model.ProdutoPedido ProdutoPedido = new Sis_Pdv_Controle_Estoque.Model.ProdutoPedido();
+            Model.ProdutoPedido ProdutoPedido = new Model.ProdutoPedido();
 
             ProdutoPedido.AlterarProdutoPedido(
                                                 request.PedidoId,
@@ -53,7 +53,7 @@ namespace Commands.ProdutoPedido.AlterarProdutoPedido
             ProdutoPedido = _repositoryProdutoPedido.Editar(ProdutoPedido);
 
             //Criar meu objeto de resposta
-            var response = new Sis_Pdv_Controle_Estoque.Commands.Response(this, ProdutoPedido);
+            var response = new Commands.Response(this, ProdutoPedido);
 
             return await Task.FromResult(response);
         }

--- a/Sis-Pdv-Controle-Estoque/Commands/ProdutoPedido/ListarProdutoPedido/ListarProdutoPedidoHandler.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/ProdutoPedido/ListarProdutoPedido/ListarProdutoPedidoHandler.cs
@@ -3,7 +3,7 @@ using prmToolkit.NotificationPattern;
 
 namespace Commands.ProdutoPedido.ListarProdutoPedido
 {
-    public class ListarProdutoPedidoPorIdHandler : Notifiable, IRequestHandler<ListarProdutoPedidoRequest, Sis_Pdv_Controle_Estoque.Commands.Response>
+    public class ListarProdutoPedidoPorIdHandler : Notifiable, IRequestHandler<ListarProdutoPedidoRequest, Commands.Response>
     {
         private readonly IMediator _mediator;
         private readonly IRepositoryProdutoPedido _repositoryProdutoPedido;
@@ -14,20 +14,20 @@ namespace Commands.ProdutoPedido.ListarProdutoPedido
             _repositoryProdutoPedido = repositoryProdutoPedido;
         }
 
-        public async Task<Sis_Pdv_Controle_Estoque.Commands.Response> Handle(ListarProdutoPedidoRequest request, CancellationToken cancellationToken)
+        public async Task<Commands.Response> Handle(ListarProdutoPedidoRequest request, CancellationToken cancellationToken)
         {
             //Valida se o objeto request esta nulo
             if (request == null)
             {
                 AddNotification("Request", "");
-                return new Sis_Pdv_Controle_Estoque.Commands.Response(this);
+                return new Commands.Response(this);
             }
 
             var grupoCollection = _repositoryProdutoPedido.Listar().ToList();
 
 
             //Cria objeto de resposta
-            var response = new Sis_Pdv_Controle_Estoque.Commands.Response(this, grupoCollection);
+            var response = new Commands.Response(this, grupoCollection);
 
             ////Retorna o resultado
             return await Task.FromResult(response);

--- a/Sis-Pdv-Controle-Estoque/Commands/ProdutoPedido/ListarProdutoPedido/ListarProdutoPedidoRequest.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/ProdutoPedido/ListarProdutoPedido/ListarProdutoPedidoRequest.cs
@@ -2,7 +2,7 @@
 
 namespace Commands.ProdutoPedido.ListarProdutoPedido
 {
-    public class ListarProdutoPedidoRequest : IRequest<Sis_Pdv_Controle_Estoque.Commands.Response>
+    public class ListarProdutoPedidoRequest : IRequest<Commands.Response>
     {
     }
 }

--- a/Sis-Pdv-Controle-Estoque/Commands/ProdutoPedido/ListarProdutoPedidoPorId/ListarProdutoPedidoPorIdHandler.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/ProdutoPedido/ListarProdutoPedidoPorId/ListarProdutoPedidoPorIdHandler.cs
@@ -3,7 +3,7 @@ using prmToolkit.NotificationPattern;
 
 namespace Commands.ProdutoPedido.ListarProdutoPedidoPorId
 {
-    public class ListarProdutoPedidoPorIdHandler : Notifiable, IRequestHandler<ListarProdutoPedidoPorIdRequest, Sis_Pdv_Controle_Estoque.Commands.Response>
+    public class ListarProdutoPedidoPorIdHandler : Notifiable, IRequestHandler<ListarProdutoPedidoPorIdRequest, Commands.Response>
     {
         private readonly IMediator _mediator;
         private readonly IRepositoryProdutoPedido _repositoryProdutoPedido;
@@ -14,13 +14,13 @@ namespace Commands.ProdutoPedido.ListarProdutoPedidoPorId
             _repositoryProdutoPedido = repositoryProdutoPedido;
         }
 
-        public async Task<Sis_Pdv_Controle_Estoque.Commands.Response> Handle(ListarProdutoPedidoPorIdRequest request, CancellationToken cancellationToken)
+        public async Task<Commands.Response> Handle(ListarProdutoPedidoPorIdRequest request, CancellationToken cancellationToken)
         {
             //Valida se o objeto request esta nulo
             if (request == null)
             {
                 AddNotification("Request", "");
-                return new Sis_Pdv_Controle_Estoque.Commands.Response(this);
+                return new Commands.Response(this);
             }
 
             var Collection =
@@ -29,11 +29,11 @@ namespace Commands.ProdutoPedido.ListarProdutoPedidoPorId
             if (Collection == null)
             {
                 AddNotification("Request", "");
-                return new Sis_Pdv_Controle_Estoque.Commands.Response(this);
+                return new Commands.Response(this);
             }
 
             //Cria objeto de resposta
-            var response = new Sis_Pdv_Controle_Estoque.Commands.Response(this, Collection.Result);
+            var response = new Commands.Response(this, Collection.Result);
 
             ////Retorna o resultado
             return await Task.FromResult(response);

--- a/Sis-Pdv-Controle-Estoque/Commands/ProdutoPedido/ListarProdutoPedidoPorId/ListarProdutoPedidoPorIdRequest.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/ProdutoPedido/ListarProdutoPedidoPorId/ListarProdutoPedidoPorIdRequest.cs
@@ -3,7 +3,7 @@ using MediatR;
 
 namespace Commands.ProdutoPedido.ListarProdutoPedidoPorId
 {
-    public class ListarProdutoPedidoPorIdRequest : IRequest<Sis_Pdv_Controle_Estoque.Commands.Response>
+    public class ListarProdutoPedidoPorIdRequest : IRequest<Commands.Response>
     {
         public ListarProdutoPedidoPorIdRequest(Guid id)
         {

--- a/Sis-Pdv-Controle-Estoque/Commands/ProdutoPedido/ListarProdutoPedidoPorPedido/ListarProdutoPedidoPorCodigoDeBarrasHandler.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/ProdutoPedido/ListarProdutoPedidoPorPedido/ListarProdutoPedidoPorCodigoDeBarrasHandler.cs
@@ -3,7 +3,7 @@ using prmToolkit.NotificationPattern;
 
 namespace Commands.ProdutoPedido.ListarProdutoPedidoPorPedido
 {
-    public class ListarProdutoPedidoPorCodigoDeBarrasHandler : Notifiable, IRequestHandler<ListarProdutoPedidoPorCodigoDeBarrasRequest, Sis_Pdv_Controle_Estoque.Commands.Response>
+    public class ListarProdutoPedidoPorCodigoDeBarrasHandler : Notifiable, IRequestHandler<ListarProdutoPedidoPorCodigoDeBarrasRequest, Commands.Response>
     {
         private readonly IMediator _mediator;
         private readonly IRepositoryProdutoPedido _repositoryProdutoPedido;
@@ -14,13 +14,13 @@ namespace Commands.ProdutoPedido.ListarProdutoPedidoPorPedido
             _repositoryProdutoPedido = repositoryProdutoPedido;
         }
 
-        public async Task<Sis_Pdv_Controle_Estoque.Commands.Response> Handle(ListarProdutoPedidoPorCodigoDeBarrasRequest request, CancellationToken cancellationToken)
+        public async Task<Commands.Response> Handle(ListarProdutoPedidoPorCodigoDeBarrasRequest request, CancellationToken cancellationToken)
         {
             //Valida se o objeto request esta nulo
             if (request == null)
             {
                 AddNotification("Erro", "Handle");
-                return new Sis_Pdv_Controle_Estoque.Commands.Response(this);
+                return new Commands.Response(this);
             }
 
             var Collection = _repositoryProdutoPedido.Listar()
@@ -28,11 +28,11 @@ namespace Commands.ProdutoPedido.ListarProdutoPedidoPorPedido
             if (!Collection.Any())
             {
                 AddNotification("ATENÇÃO", "ProdutoPedido NÃO ENCONTRADA");
-                return new Sis_Pdv_Controle_Estoque.Commands.Response(this);
+                return new Commands.Response(this);
             }
 
             //Criar meu objeto de resposta
-            var response = new Sis_Pdv_Controle_Estoque.Commands.Response(this, Collection);
+            var response = new Commands.Response(this, Collection);
             //Cria objeto de resposta
 
             ////Retorna o resultado

--- a/Sis-Pdv-Controle-Estoque/Commands/ProdutoPedido/ListarProdutoPedidoPorPedido/ListarProdutoPedidoPorCodigoDeBarrasRequest.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/ProdutoPedido/ListarProdutoPedidoPorPedido/ListarProdutoPedidoPorCodigoDeBarrasRequest.cs
@@ -2,7 +2,7 @@
 
 namespace Commands.ProdutoPedido.ListarProdutoPedidoPorPedido
 {
-    public class ListarProdutoPedidoPorCodigoDeBarrasRequest : IRequest<Sis_Pdv_Controle_Estoque.Commands.Response>
+    public class ListarProdutoPedidoPorCodigoDeBarrasRequest : IRequest<Commands.Response>
     {
         public ListarProdutoPedidoPorCodigoDeBarrasRequest(string codBarras)
         {

--- a/Sis-Pdv-Controle-Estoque/Commands/ProdutoPedido/RemoverProdutoPedido/RemoverProdutoPedidoHandler.cs
+++ b/Sis-Pdv-Controle-Estoque/Commands/ProdutoPedido/RemoverProdutoPedido/RemoverProdutoPedidoHandler.cs
@@ -4,7 +4,7 @@ using prmToolkit.NotificationPattern;
 namespace Commands.ProdutoPedido.RemoverProdutoPedido
 
 {
-    public class RemoverProdutoPedidoHandler : Notifiable, IRequestHandler<RemoverProdutoPedidoResquest, Sis_Pdv_Controle_Estoque.Commands.Response>
+    public class RemoverProdutoPedidoHandler : Notifiable, IRequestHandler<RemoverProdutoPedidoResquest, Commands.Response>
     {
         private readonly IMediator _mediator;
         private readonly IRepositoryProdutoPedido _repositoryProdutoPedido;
@@ -15,21 +15,21 @@ namespace Commands.ProdutoPedido.RemoverProdutoPedido
             _repositoryProdutoPedido = repositoryProdutoPedido;
         }
 
-        public async Task<Sis_Pdv_Controle_Estoque.Commands.Response> Handle(RemoverProdutoPedidoResquest request, CancellationToken cancellationToken)
+        public async Task<Commands.Response> Handle(RemoverProdutoPedidoResquest request, CancellationToken cancellationToken)
         {
             //Valida se o objeto request esta nulo
             if (request == null)
             {
                 AddNotification("Request", "");
-                return new Sis_Pdv_Controle_Estoque.Commands.Response(this);
+                return new Commands.Response(this);
             }
 
-            Sis_Pdv_Controle_Estoque.Model.ProdutoPedido ProdutoPedido = _repositoryProdutoPedido.ObterPorId(request.Id);
+            Model.ProdutoPedido ProdutoPedido = _repositoryProdutoPedido.ObterPorId(request.Id);
 
             if (ProdutoPedido == null)
             {
                 AddNotification("Request", "");
-                return new Sis_Pdv_Controle_Estoque.Commands.Response(this);
+                return new Commands.Response(this);
             }
 
             _repositoryProdutoPedido.Remover(ProdutoPedido);
@@ -37,7 +37,7 @@ namespace Commands.ProdutoPedido.RemoverProdutoPedido
             var result = new { Id = ProdutoPedido.Id };
 
             //Cria objeto de resposta
-            var response = new Sis_Pdv_Controle_Estoque.Commands.Response(this, result);
+            var response = new Commands.Response(this, result);
 
             ////Retorna o resultado
             return await Task.FromResult(response);

--- a/Sis-Pdv-Controle-Estoque/GlobalUsings.cs
+++ b/Sis-Pdv-Controle-Estoque/GlobalUsings.cs
@@ -1,0 +1,4 @@
+global using Interfaces;
+global using Interfaces.Repositories.Base;
+global using Model;
+global using Model.Base;

--- a/Sis-Pdv-Controle-Estoque/Interfaces/IRepositoryPedido.cs
+++ b/Sis-Pdv-Controle-Estoque/Interfaces/IRepositoryPedido.cs
@@ -1,4 +1,6 @@
-﻿namespace Interfaces
+using Commands.Pedidos.ListarVendaPedidoPorData;
+
+namespace Interfaces
 {
     public interface IRepositoryPedido : IRepositoryBase<Pedido, Guid>
     {


### PR DESCRIPTION
## Summary
- add `GlobalUsings.cs` in domain and infra projects
- update repository interfaces to use new namespace
- adjust command handlers to reference new namespaces

## Testing
- `dotnet build Sis-Pdv-Controle-Estoque/Sis-Pdv-Controle-Estoque-Domain.csproj`
- `dotnet build Sis-Pdv-Controle-Estoque-Infra/Sis-Pdv-Controle-Estoque-Infra.csproj` *(fails: PdvContext not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850dd33e5988321a6fd70d1dde89d83