### PR TITLE
Remove EF annotations from domain models

### DIFF
--- a/Sis-Pdv-Controle-Estoque/Model/Cliente.cs
+++ b/Sis-Pdv-Controle-Estoque/Model/Cliente.cs
@@ -1,8 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations.Schema;
-
 namespace Model
 {
-    [Table("Cliente")]
     public class Cliente : EntityBase
     {
         public Cliente()

--- a/Sis-Pdv-Controle-Estoque/Model/Colaborador.cs
+++ b/Sis-Pdv-Controle-Estoque/Model/Colaborador.cs
@@ -1,8 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations.Schema;
-
 namespace Model
 {
-    [Table("Colaborador")]
     public class Colaborador : EntityBase
     {
 

--- a/Sis-Pdv-Controle-Estoque/Model/Departamento.cs
+++ b/Sis-Pdv-Controle-Estoque/Model/Departamento.cs
@@ -1,8 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations.Schema;
-
 namespace Model
 {
-    [Table("Departamento")]
     public class Departamento : EntityBase
     {
         public Departamento()

--- a/Sis-Pdv-Controle-Estoque/Model/Fornecedor.cs
+++ b/Sis-Pdv-Controle-Estoque/Model/Fornecedor.cs
@@ -1,8 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations.Schema;
-
 namespace Model
 {
-    [Table("Fornecedor")]
     public class Fornecedor : EntityBase
     {
         public Fornecedor()

--- a/Sis-Pdv-Controle-Estoque/Model/Produto.cs
+++ b/Sis-Pdv-Controle-Estoque/Model/Produto.cs
@@ -1,8 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations.Schema;
-
 namespace Model
 {
-    [Table("Produto")]
     public class Produto : EntityBase
     {
 

--- a/Sis-Pdv-Controle-Estoque/Model/ProdutoPedido.cs
+++ b/Sis-Pdv-Controle-Estoque/Model/ProdutoPedido.cs
@@ -1,8 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations.Schema;
-
 namespace Model
 {
-    [Table("ProdutoPedido")]
     public class ProdutoPedido : EntityBase
     {
         public ProdutoPedido()

--- a/Sis-Pdv-Controle-Estoque/Model/ProdutoPedidoBase.cs
+++ b/Sis-Pdv-Controle-Estoque/Model/ProdutoPedidoBase.cs
@@ -1,8 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations.Schema;
-
 namespace Model
 {
-    [Table("ProdutoPedido")]
     public class ProdutoPedidoBase
     {
         public string codItem { get; set; }

--- a/Sis-Pdv-Controle-Estoque/Model/Usuario.cs
+++ b/Sis-Pdv-Controle-Estoque/Model/Usuario.cs
@@ -1,8 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations.Schema;
-
 namespace Model
 {
-    [Table("Usuario")]
     public class Usuario : EntityBase
     {
         public Usuario()


### PR DESCRIPTION
## Summary
- clean domain models of `[Table]` annotations
- keep table mapping in infrastructure

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854831a67948321af7a77ff72ef2447