### PR TITLE
Fix login and collaborator status handling

### DIFF
--- a/Sis-Pdv-Controle-Estoque-Form/Paginas/Colaborador/CadColaborador.cs
+++ b/Sis-Pdv-Controle-Estoque-Form/Paginas/Colaborador/CadColaborador.cs
@@ -130,7 +130,7 @@ namespace Sis_Pdv_Controle_Estoque_Form.Paginas.Colaborador
             }
             else
             {
-                _ativo = true;
+                _ativo = false;
             }
         }
         private async Task Excluir(ColaboradorDto dto)
@@ -261,7 +261,7 @@ namespace Sis_Pdv_Controle_Estoque_Form.Paginas.Colaborador
             {
                 rbInativo.Checked = true;
                 rbAtivo.Checked = false;
-                _ativo = true;
+                _ativo = false;
             }
 
 

--- a/Sis-Pdv-Controle-Estoque-Form/Paginas/Colaborador/frmColaborador.cs
+++ b/Sis-Pdv-Controle-Estoque-Form/Paginas/Colaborador/frmColaborador.cs
@@ -52,7 +52,7 @@ namespace Sis_Pdv_Controle_Estoque_Form.Paginas.Colaborador
             {
                 rbInativo.Checked = true;
                 rbAtivo.Checked = false;
-                _ativo = true;
+                _ativo = false;
             }
 
 
@@ -153,7 +153,7 @@ namespace Sis_Pdv_Controle_Estoque_Form.Paginas.Colaborador
             }
             else
             {
-                _ativo = true;
+                _ativo = false;
             }
         }
         private async Task Excluir(ColaboradorDto dto)

--- a/Sis-Pdv-Controle-Estoque-Form/Paginas/Login/frmLogin.cs
+++ b/Sis-Pdv-Controle-Estoque-Form/Paginas/Login/frmLogin.cs
@@ -113,7 +113,7 @@ namespace Sis_Pdv_Controle_Estoque_Form.Paginas.Login
             txtSenha.Text = "SENHA";
             txtSenha.UseSystemPasswordChar = false;
 
-            txtSenha.Text = "USUARIO";
+            txtLogin.Text = "USUARIO";
 
             this.Show();
             txtLogin.Focus();


### PR DESCRIPTION
## Summary
- correct input reset when logging out of login form
- fix collaborator active/inactive toggle logic

## Testing
- `dotnet test Sis-Pdv-Controle-Estoque.sln` *(fails: "dotnet: command not found")*


------
https://chatgpt.com/codex/tasks/task_e_6854916aec6c8321b807ed5048340d23